### PR TITLE
Shortened metadata.max.age.ms to make mirror topics show up faster

### DIFF
--- a/workshops/hybrid-cloud-workshop-one-cluster-linking/core/asciidoc/bits/main-cl-edges-hq.adoc
+++ b/workshops/hybrid-cloud-workshop-one-cluster-linking/core/asciidoc/bits/main-cl-edges-hq.adoc
@@ -337,9 +337,13 @@ curl --request POST \
       "value": "INBOUND"
     },
     {
++     "name": "metadata.max.age.ms",
++     "value": "15000"
++   },  
+    {
       "name": "acl.sync.enable",
       "value": "false"
-    },
+    },  
     {
       "name": "auto.create.mirror.topics.enable",
       "value": "true"
@@ -504,6 +508,10 @@ curl --request POST \
       "name": "connection.mode",
       "value": "INBOUND"
     },
++   {
++     "name": "metadata.max.age.ms",
++     "value": "15000"
++   },      
     {
       "name": "acl.sync.enable",
       "value": "false"

--- a/workshops/hybrid-cloud-workshop-one-cluster-linking/core/asciidoc/bits/main-cl.adoc
+++ b/workshops/hybrid-cloud-workshop-one-cluster-linking/core/asciidoc/bits/main-cl.adoc
@@ -336,6 +336,10 @@ curl --request POST \
       "name": "connection.mode",
       "value": "INBOUND"
     },
++   {
++     "name": "metadata.max.age.ms",
++     "value": "15000"
++   },      
     {
       "name": "acl.sync.enable",
       "value": "false"

--- a/workshops/hybrid-cloud-workshop-one-cluster-linking/core/dev/cluster-link-1.sh
+++ b/workshops/hybrid-cloud-workshop-one-cluster-linking/core/dev/cluster-link-1.sh
@@ -74,6 +74,10 @@ curl --request POST \
       "name": "acl.sync.enable",
       "value": "false"
     },
++   {
++     "name": "metadata.max.age.ms",
++     "value": "15000"
++   },      
     {
       "name": "auto.create.mirror.topics.enable",
       "value": "true"
@@ -141,6 +145,10 @@ curl --request POST \
       "name": "connection.mode",
       "value": "INBOUND"
     },
++   {
++     "name": "metadata.max.age.ms",
++     "value": "15000"
++   },  
     {
       "name": "acl.sync.enable",
       "value": "false"


### PR DESCRIPTION
The default of 5 mins was making it too long for mirror topics to be created so set it to 15 seconds for the DIMT labs.