### PR TITLE
Fixes for GCP deployment

### DIFF
--- a/core/terraform/gcp/workshop-core/main.tf
+++ b/core/terraform/gcp/workshop-core/main.tf
@@ -66,7 +66,7 @@ resource "google_compute_instance" "instance" {
   boot_disk {
     initialize_params {
       type  = "pd-standard"
-      image = "ubuntu-1804-lts"
+      image = "ubuntu-2004-lts"
       size  = var.vm_disk_size
     }
   }

--- a/workshop-example-gcp.yaml
+++ b/workshop-example-gcp.yaml
@@ -26,6 +26,7 @@ workshop:
     ccloud_bootstrap_servers: <CCloud Bootstrap Server>
     ccloud_api_key: <CCloud API Key>
     ccloud_api_secret: <CCloud API Secret>
+    ccloud_sr_region: europe-west2
 
     # List of ccloud topics to pre-create
     ccloud_topics: sales_orders,sales_order_details,purchase_orders,purchase_order_details,customers,suppliers,products


### PR DESCRIPTION
1. ubuntu-1804-lts image no longer available
2. missing ccloud_sr_region parameter